### PR TITLE
fix: give each target its own HTTP client

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,16 +24,59 @@ var (
 	timeout = flag.Duration("timeout", 8*time.Second, "Timeout for network operations")
 )
 
-var httpClient *http.Client
+// httpTarget pairs a target with the client that probes it. Each target gets
+// its own client, because each one can have a different certificate
+// authority.
+type httpTarget struct {
+	domain string
+	client *http.Client
+}
 
 type Exporter struct {
-	config *Config
+	httpTargets []httpTarget
+	smtpTargets []SMTPDomain
 
 	certificates *prometheus.GaugeVec
 	status       *prometheus.GaugeVec
 }
 
-func NewSSLExporter() *Exporter {
+// newHTTPClient builds the client for one target. The TLS settings go in the
+// transport of the client, so no probe writes to shared state.
+func newHTTPClient(target HTTPDomain, timeout time.Duration) (*http.Client, error) {
+	tlsConfig, err := TLSConfig(target.Domain, target.CAFile, target.InsecureSkipVerify)
+	if err != nil {
+		return nil, fmt.Errorf("TLS settings for %s: %w", target.Domain, err)
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}, nil
+}
+
+func NewSSLExporter(config *Config, timeout time.Duration) (*Exporter, error) {
+	exporter := newExporter()
+
+	for _, target := range config.HTTPDomains {
+		client, err := newHTTPClient(target, timeout)
+		if err != nil {
+			return nil, err
+		}
+		exporter.httpTargets = append(exporter.httpTargets, httpTarget{
+			domain: target.Domain,
+			client: client,
+		})
+	}
+
+	exporter.smtpTargets = config.SMTPDomains
+
+	return exporter, nil
+}
+
+func newExporter() *Exporter {
 	return &Exporter{
 		certificates: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -79,9 +122,9 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(len(e.config.HTTPDomains))
+		wg.Add(len(e.httpTargets))
 
-		for _, target := range e.config.HTTPDomains {
+		for _, target := range e.httpTargets {
 
 			target := target
 
@@ -104,9 +147,9 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(len(e.config.SMTPDomains))
+		wg.Add(len(e.smtpTargets))
 
-		for _, target := range e.config.SMTPDomains {
+		for _, target := range e.smtpTargets {
 
 			target := target
 
@@ -130,28 +173,19 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 }
 
-func (e *Exporter) collectHTTPDomain(target HTTPDomain) {
+func (e *Exporter) collectHTTPDomain(target httpTarget) {
 
-	domain := target.Domain
+	domain := target.domain
 
-	req, _ := http.NewRequest("GET", fmt.Sprintf("https://%s/", domain), nil)
-	req.Header.Set("User-Agent", "prometheus-ssl-exporter/0.1 (SSL monitoring)")
-
-	tlsConfig, err := TLSConfig(domain, target.CAFile, target.InsecureSkipVerify)
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/", domain), nil)
 	if err != nil {
-		log.Printf("error preparing TLS config for %v: %v", domain, err)
+		log.Printf("error building the request for %v: %v", domain, err)
 		e.status.WithLabelValues("http", domain).Set(0)
 		return
 	}
+	req.Header.Set("User-Agent", "prometheus-ssl-exporter/0.1 (SSL monitoring)")
 
-	// TODO: this writes to the shared client on every probe, which is a data
-	// race between the goroutines of one scrape. A later commit gives each
-	// target its own client.
-	httpClient.Transport = &http.Transport{
-		TLSClientConfig: tlsConfig,
-	}
-
-	resp, err := httpClient.Do(req)
+	resp, err := target.client.Do(req)
 	if err != nil {
 		log.Printf("error connecting to %v: %v", domain, err)
 		e.status.WithLabelValues("http", domain).Set(0)
@@ -232,17 +266,15 @@ func main() {
 
 	flag.Parse()
 
-	httpClient = &http.Client{
-		Timeout: *timeout,
-	}
-
 	config, err := LoadConfig(*conf)
 	if err != nil {
 		log.Fatalf("couldn't load the configuration: %v", err)
 	}
 
-	exporter := NewSSLExporter()
-	exporter.config = config
+	exporter, err := NewSSLExporter(config, *timeout)
+	if err != nil {
+		log.Fatalf("couldn't build the exporter: %v", err)
+	}
 
 	prometheus.MustRegister(exporter)
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestNewHTTPClientPerTarget shows that two targets get two clients, and that
+// each client carries the TLS settings of its own target. One shared client
+// cannot hold two different certificate authorities at the same time.
+func TestNewHTTPClientPerTarget(t *testing.T) {
+	strict := HTTPDomain{Domain: "strict.example.com"}
+	relaxed := HTTPDomain{Domain: "relaxed.example.com", InsecureSkipVerify: true}
+
+	strictClient, err := newHTTPClient(strict, time.Second)
+	if err != nil {
+		t.Fatalf("newHTTPClient for the strict target: %v", err)
+	}
+
+	relaxedClient, err := newHTTPClient(relaxed, time.Second)
+	if err != nil {
+		t.Fatalf("newHTTPClient for the relaxed target: %v", err)
+	}
+
+	if strictClient == relaxedClient {
+		t.Fatal("both targets got the same client")
+	}
+
+	strictTransport, ok := strictClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("strict transport: got %T, want *http.Transport", strictClient.Transport)
+	}
+	relaxedTransport, ok := relaxedClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("relaxed transport: got %T, want *http.Transport", relaxedClient.Transport)
+	}
+
+	if strictTransport == relaxedTransport {
+		t.Fatal("both targets got the same transport")
+	}
+
+	if got := strictTransport.TLSClientConfig.InsecureSkipVerify; got {
+		t.Errorf("strict InsecureSkipVerify: got %v, want false", got)
+	}
+	if got := relaxedTransport.TLSClientConfig.InsecureSkipVerify; !got {
+		t.Errorf("relaxed InsecureSkipVerify: got %v, want true", got)
+	}
+
+	if got := strictTransport.TLSClientConfig.ServerName; got != "strict.example.com" {
+		t.Errorf("strict ServerName: got %q, want %q", got, "strict.example.com")
+	}
+	if got := relaxedTransport.TLSClientConfig.ServerName; got != "relaxed.example.com" {
+		t.Errorf("relaxed ServerName: got %q, want %q", got, "relaxed.example.com")
+	}
+
+	if strictClient.Timeout != time.Second {
+		t.Errorf("Timeout: got %v, want %v", strictClient.Timeout, time.Second)
+	}
+}
+
+// TestCollectConcurrentTargets probes several targets in one scrape. The race
+// detector reports the shared-client fault here, because every probe runs in
+// its own goroutine.
+func TestCollectConcurrentTargets(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "https://")
+
+	config := &Config{}
+	for i := 0; i < 8; i++ {
+		config.HTTPDomains = append(config.HTTPDomains, HTTPDomain{
+			Domain: host,
+			// The certificate of the test server names 127.0.0.1, not the
+			// host and port that the probe sends as the server name.
+			InsecureSkipVerify: true,
+		})
+	}
+
+	exporter, err := NewSSLExporter(config, 5*time.Second)
+	if err != nil {
+		t.Fatalf("NewSSLExporter: %v", err)
+	}
+
+	registry := prometheus.NewPedanticRegistry()
+	if err := registry.Register(exporter); err != nil {
+		t.Fatalf("register the exporter: %v", err)
+	}
+
+	// Two scrapes at the same time, as two Prometheus servers would do.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := registry.Gather(); err != nil {
+				t.Errorf("Gather: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	var up float64
+	var found bool
+	for _, family := range families {
+		if family.GetName() != "ssl_endpoint_up" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			found = true
+			up = metric.GetGauge().GetValue()
+		}
+	}
+
+	if !found {
+		t.Fatal("ssl_endpoint_up is not in the gathered metrics")
+	}
+	if up != 1 {
+		t.Errorf("ssl_endpoint_up: got %v, want 1", up)
+	}
+}
+
+// TestNewSSLExporterRejectsBadCA stops a target with a CA file that the
+// exporter cannot read.
+func TestNewSSLExporterRejectsBadCA(t *testing.T) {
+	config := &Config{
+		HTTPDomains: []HTTPDomain{{
+			Domain: "internal.example.com",
+			CAFile: "/does/not/exist.pem",
+		}},
+	}
+
+	_, err := NewSSLExporter(config, time.Second)
+	if err == nil {
+		t.Fatal("NewSSLExporter returned no error for a CA file that does not exist")
+	}
+	if !strings.Contains(err.Error(), "internal.example.com") {
+		t.Errorf("error %q does not name the target", err)
+	}
+}


### PR DESCRIPTION
This removes a data race in the HTTP probe.

## The fault

The HTTP probe wrote the TLS settings into one shared client:

```go
httpClient.Transport = &http.Transport{TLSClientConfig: tlsConfig}
resp, err := httpClient.Do(req)
```

`Collect` starts one goroutine for each target. The probes of one scrape
then wrote and read `httpClient.Transport` at the same time. This is a
data race, and `go test -race` reports it.

The result is also wrong. The last write wins, so a target can use the
certificate authority of a different target. A target with a private
authority can report as down, and a target that needs a check can get
`InsecureSkipVerify` from another target.

## The correction

Each target gets a client at startup, and that client holds the TLS
settings of the target. No probe writes to shared state.

## Other changes

- Delete the package-level `httpClient` variable.
- `NewSSLExporter` takes the configuration and the timeout, and returns
  an error. A CA file that the exporter cannot read stops it at startup.
- Build the transport from a clone of `http.DefaultTransport`. This keeps
  the proxy settings and the connection pool. The old code built a bare
  transport on every probe, so no connection was reused.
- Check the error from `http.NewRequest`. The old code dropped it and
  then used the request on the next line.

## Tests

- `TestNewHTTPClientPerTarget` shows that two targets get two clients and
  two transports, and that each transport holds the settings of its own
  target.
- `TestCollectConcurrentTargets` runs a scrape over eight targets, and
  runs two scrapes at the same time. The race detector reports the old
  fault in this test.
- `TestNewSSLExporterRejectsBadCA` makes sure that the error names the
  target.

