### PR TITLE
fix: build the metrics from each scrape

### DIFF
--- a/collect_test.go
+++ b/collect_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// gatherMetric returns the value of one metric of one target, and reports
+// whether the series is in the output at all.
+func gatherMetric(t *testing.T, registry *prometheus.Registry, name string) (float64, bool) {
+	t.Helper()
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		metrics := family.GetMetric()
+		if len(metrics) == 0 {
+			return 0, false
+		}
+		return metrics[0].GetGauge().GetValue(), true
+	}
+
+	return 0, false
+}
+
+// registerTarget builds an exporter for one HTTPS target and registers it.
+func registerTarget(t *testing.T, host string) *prometheus.Registry {
+	t.Helper()
+
+	exporter, err := NewSSLExporter(&Config{
+		HTTPDomains: []HTTPDomain{{Domain: host, InsecureSkipVerify: true}},
+	}, 3*time.Second)
+	if err != nil {
+		t.Fatalf("NewSSLExporter: %v", err)
+	}
+
+	registry := prometheus.NewPedanticRegistry()
+	if err := registry.Register(exporter); err != nil {
+		t.Fatalf("register the exporter: %v", err)
+	}
+
+	return registry
+}
+
+// TestExpiryLeavesTheOutputWhenTheProbeFails is the regression test for the
+// stored gauges. The old collector kept the last good value, so a target that
+// stopped answering still reported days left on its certificate.
+func TestExpiryLeavesTheOutputWhenTheProbeFails(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+	host := strings.TrimPrefix(server.URL, "https://")
+	registry := registerTarget(t, host)
+
+	up, ok := gatherMetric(t, registry, "ssl_endpoint_up")
+	if !ok || up != 1 {
+		t.Fatalf("first scrape ssl_endpoint_up: got %v (present %v), want 1", up, ok)
+	}
+	if _, ok := gatherMetric(t, registry, "ssl_certificate_days_left"); !ok {
+		t.Fatal("first scrape: ssl_certificate_days_left is not in the output")
+	}
+
+	// The target stops answering.
+	server.Close()
+
+	up, ok = gatherMetric(t, registry, "ssl_endpoint_up")
+	if !ok || up != 0 {
+		t.Errorf("second scrape ssl_endpoint_up: got %v (present %v), want 0", up, ok)
+	}
+	if value, ok := gatherMetric(t, registry, "ssl_certificate_days_left"); ok {
+		t.Errorf("second scrape ssl_certificate_days_left: got %v, want the series to leave the output", value)
+	}
+}
+
+// TestRedirectToPlainHTTP covers a target that answers on HTTPS and then
+// redirects to plain HTTP. The response of such a target carries no TLS
+// state. The old collector read the certificate from it and stopped the
+// exporter.
+func TestRedirectToPlainHTTP(t *testing.T) {
+	plain := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+	defer plain.Close()
+
+	secure := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, plain.URL, http.StatusFound)
+		}))
+	defer secure.Close()
+
+	registry := registerTarget(t, strings.TrimPrefix(secure.URL, "https://"))
+
+	up, ok := gatherMetric(t, registry, "ssl_endpoint_up")
+	if !ok {
+		t.Fatal("ssl_endpoint_up is not in the output")
+	}
+	if up != 0 {
+		t.Errorf("ssl_endpoint_up: got %v, want 0", up)
+	}
+	if _, ok := gatherMetric(t, registry, "ssl_certificate_days_left"); ok {
+		t.Error("ssl_certificate_days_left is in the output for a target with no TLS")
+	}
+}
+
+// TestTargetLeavesTheOutput makes sure that a target reports nothing after it
+// leaves the configuration. The stored gauges held such a series until a
+// restart.
+func TestTargetLeavesTheOutput(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "https://")
+
+	withTarget := registerTarget(t, host)
+	if _, ok := gatherMetric(t, withTarget, "ssl_endpoint_up"); !ok {
+		t.Fatal("ssl_endpoint_up is not in the output of the first exporter")
+	}
+
+	// The same exporter with no target at all.
+	empty, err := NewSSLExporter(&Config{}, 3*time.Second)
+	if err != nil {
+		t.Fatalf("NewSSLExporter: %v", err)
+	}
+	registry := prometheus.NewPedanticRegistry()
+	if err := registry.Register(empty); err != nil {
+		t.Fatalf("register the exporter: %v", err)
+	}
+
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	if len(families) != 0 {
+		var names []string
+		for _, family := range families {
+			names = append(names, family.GetName())
+		}
+		t.Errorf("families: got %v, want none", names)
+	}
+}
+
+func TestDaysLeft(t *testing.T) {
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		notAfter time.Time
+		want     float64
+	}{
+		{
+			name:     "one day left",
+			notAfter: now.Add(24 * time.Hour),
+			want:     1,
+		},
+		{
+			name:     "half a day left",
+			notAfter: now.Add(12 * time.Hour),
+			want:     0.5,
+		},
+		{
+			name:     "the certificate ended a day ago",
+			notAfter: now.Add(-24 * time.Hour),
+			want:     -1,
+		},
+		{
+			name:     "the certificate ends now",
+			notAfter: now,
+			want:     0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := daysLeft(test.notAfter, now); got != test.want {
+				t.Errorf("daysLeft: got %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+// TestDescribeNamesBothMetrics keeps the registry able to find the metrics
+// before the first scrape.
+func TestDescribeNamesBothMetrics(t *testing.T) {
+	exporter, err := NewSSLExporter(&Config{}, time.Second)
+	if err != nil {
+		t.Fatalf("NewSSLExporter: %v", err)
+	}
+
+	descs := make(chan *prometheus.Desc, 8)
+	exporter.Describe(descs)
+	close(descs)
+
+	var got []string
+	for desc := range descs {
+		got = append(got, desc.String())
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("Describe sent %d descriptions, want 2", len(got))
+	}
+
+	joined := strings.Join(got, " ")
+	for _, name := range []string{"ssl_endpoint_up", "ssl_certificate_days_left"} {
+		if !strings.Contains(joined, name) {
+			t.Errorf("Describe did not name %s", name)
+		}
+	}
+}

--- a/config.go
+++ b/config.go
@@ -81,10 +81,22 @@ func LoadConfig(path string) (*Config, error) {
 
 // Validate reports the first fault that it finds in the configuration.
 func (c *Config) Validate() error {
+	// The metrics carry the labels "type" and "domain" only. Two targets of
+	// the same type and domain give two series with the same labels, which
+	// makes the whole scrape fail.
+	httpSeen := make(map[string]int, len(c.HTTPDomains))
+	smtpSeen := make(map[string]int, len(c.SMTPDomains))
+
 	for i, target := range c.HTTPDomains {
 		if target.Domain == "" {
 			return fmt.Errorf("http_domains[%d]: domain is required", i)
 		}
+		if first, ok := httpSeen[target.Domain]; ok {
+			return fmt.Errorf("http_domains[%d] %q: domain is already at http_domains[%d]",
+				i, target.Domain, first)
+		}
+		httpSeen[target.Domain] = i
+
 		if _, err := TLSConfig(target.Domain, target.CAFile, target.InsecureSkipVerify); err != nil {
 			return fmt.Errorf("http_domains[%d] %q: %w", i, target.Domain, err)
 		}
@@ -94,6 +106,12 @@ func (c *Config) Validate() error {
 		if target.Domain == "" {
 			return fmt.Errorf("smtp_domains[%d]: domain is required", i)
 		}
+		if first, ok := smtpSeen[target.Domain]; ok {
+			return fmt.Errorf("smtp_domains[%d] %q: domain is already at smtp_domains[%d]",
+				i, target.Domain, first)
+		}
+		smtpSeen[target.Domain] = i
+
 		if target.Port < 1 || target.Port > 65535 {
 			return fmt.Errorf("smtp_domains[%d] %q: port %d is outside the range 1-65535",
 				i, target.Domain, target.Port)

--- a/config_test.go
+++ b/config_test.go
@@ -236,6 +236,33 @@ func TestConfigValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "the same HTTP domain twice",
+			config: Config{
+				HTTPDomains: []HTTPDomain{
+					{Domain: "www.example.com"},
+					{Domain: "www.example.com", InsecureSkipVerify: true},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "the same SMTP domain on two ports",
+			config: Config{
+				SMTPDomains: []SMTPDomain{
+					{Domain: "mail.example.com", Port: 25},
+					{Domain: "mail.example.com", Port: 587},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "the same domain for HTTP and SMTP",
+			config: Config{
+				HTTPDomains: []HTTPDomain{{Domain: "mail.example.com"}},
+				SMTPDomains: []SMTPDomain{{Domain: "mail.example.com", Port: 587}},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/main.go
+++ b/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -42,10 +42,35 @@ type smtpTarget struct {
 type Exporter struct {
 	httpTargets []httpTarget
 	smtpTargets []smtpTarget
-
-	certificates *prometheus.GaugeVec
-	status       *prometheus.GaugeVec
+	timeout     time.Duration
 }
+
+// result is the outcome of one probe. Collect turns it into metrics.
+type result struct {
+	probeType string
+	domain    string
+	up        bool
+	notAfter  time.Time
+}
+
+// errNoTLS reports a response that carries no TLS state. An HTTPS target
+// that redirects to plain HTTP gives such a response.
+var errNoTLS = errors.New("the connection did not use TLS")
+
+// errNoPeerCertificate reports a TLS state with an empty certificate chain.
+var errNoPeerCertificate = errors.New("the peer sent no certificate")
+
+var (
+	certDaysLeftDesc = prometheus.NewDesc(
+		"ssl_certificate_days_left",
+		"Number of days left on the certificate",
+		[]string{"type", "domain"}, nil)
+
+	endpointUpDesc = prometheus.NewDesc(
+		"ssl_endpoint_up",
+		"Was the last SSL poll successful",
+		[]string{"type", "domain"}, nil)
+)
 
 // newHTTPClient builds the client for one target. The TLS settings go in the
 // transport of the client, so no probe writes to shared state.
@@ -65,7 +90,7 @@ func newHTTPClient(target HTTPDomain, timeout time.Duration) (*http.Client, erro
 }
 
 func NewSSLExporter(config *Config, timeout time.Duration) (*Exporter, error) {
-	exporter := newExporter()
+	exporter := &Exporter{timeout: timeout}
 
 	for _, target := range config.HTTPDomains {
 		client, err := newHTTPClient(target, timeout)
@@ -93,192 +118,155 @@ func NewSSLExporter(config *Config, timeout time.Duration) (*Exporter, error) {
 	return exporter, nil
 }
 
-func newExporter() *Exporter {
-	return &Exporter{
-		certificates: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "ssl",
-				Subsystem: "certificate",
-				Name:      "days_left",
-				Help:      "Number of days left on the certificate",
-			},
-			[]string{
-				"type",
-				"domain",
-			},
-		),
-		status: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "ssl",
-				Subsystem: "endpoint",
-				Name:      "up",
-				Help:      "Was the last SSL poll successful",
-			},
-			[]string{
-				"type",
-				"domain",
-			},
-		),
+func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
+	ch <- endpointUpDesc
+	ch <- certDaysLeftDesc
+}
+
+// Collect probes every target and writes the metrics of this scrape. It
+// builds the metrics from the results of this scrape only, so a target that
+// leaves the configuration leaves the output, and a probe that fails reports
+// no expiry.
+func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
+
+	results := make([]result, len(e.httpTargets)+len(e.smtpTargets))
+
+	var wg sync.WaitGroup
+	wg.Add(len(results))
+
+	for i, target := range e.httpTargets {
+		go func(slot int, target httpTarget) {
+			defer wg.Done()
+			results[slot] = e.probe(probeHTTP(target))
+		}(i, target)
+	}
+
+	offset := len(e.httpTargets)
+
+	for i, target := range e.smtpTargets {
+		go func(slot int, target smtpTarget) {
+			defer wg.Done()
+			results[slot] = e.probe(probeSMTP(target, e.timeout))
+		}(offset+i, target)
+	}
+
+	wg.Wait()
+
+	now := time.Now()
+
+	for _, res := range results {
+		up := 0.0
+		if res.up {
+			up = 1
+		}
+
+		ch <- prometheus.MustNewConstMetric(endpointUpDesc,
+			prometheus.GaugeValue, up, res.probeType, res.domain)
+
+		if !res.up {
+			continue
+		}
+
+		ch <- prometheus.MustNewConstMetric(certDaysLeftDesc,
+			prometheus.GaugeValue, daysLeft(res.notAfter, now),
+			res.probeType, res.domain)
 	}
 }
 
-func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	e.certificates.Describe(ch)
-	e.status.Describe(ch)
-}
-
-func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
-
-	var top sync.WaitGroup
-
-	top.Add(2)
-
-	go func() {
-
-		// Collect HTTP domains
-
-		var wg sync.WaitGroup
-
-		wg.Add(len(e.httpTargets))
-
-		for _, target := range e.httpTargets {
-
-			target := target
-
-			go func() {
-				e.collectHTTPDomain(target)
-				wg.Done()
-			}()
-
-		}
-
-		wg.Wait()
-
-		top.Done()
-
-	}()
-
-	go func() {
-
-		// Collect SMTP domains
-
-		var wg sync.WaitGroup
-
-		wg.Add(len(e.smtpTargets))
-
-		for _, target := range e.smtpTargets {
-
-			target := target
-
-			go func() {
-				e.collectSMTPDomain(target)
-				wg.Done()
-			}()
-
-		}
-
-		wg.Wait()
-
-		top.Done()
-
-	}()
-
-	top.Wait()
-
-	e.certificates.Collect(ch)
-	e.status.Collect(ch)
-
-}
-
-func (e *Exporter) collectHTTPDomain(target httpTarget) {
-
-	domain := target.domain
-
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/", domain), nil)
+// probe logs the error of a probe and returns its result.
+func (e *Exporter) probe(res result, err error) result {
 	if err != nil {
-		log.Printf("error building the request for %v: %v", domain, err)
-		e.status.WithLabelValues("http", domain).Set(0)
-		return
+		log.Printf("probe %s target %s: %v", res.probeType, res.domain, err)
+	}
+	return res
+}
+
+// daysLeft gives the days between now and the end of the certificate. The
+// value is negative for a certificate that ended.
+func daysLeft(notAfter, now time.Time) float64 {
+	return notAfter.Sub(now).Hours() / 24
+}
+
+func probeHTTP(target httpTarget) (result, error) {
+
+	res := result{probeType: "http", domain: target.domain}
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/", target.domain), nil)
+	if err != nil {
+		return res, fmt.Errorf("build the request: %w", err)
 	}
 	req.Header.Set("User-Agent", "prometheus-ssl-exporter/0.1 (SSL monitoring)")
 
 	resp, err := target.client.Do(req)
 	if err != nil {
-		log.Printf("error connecting to %v: %v", domain, err)
-		e.status.WithLabelValues("http", domain).Set(0)
-		return
+		return res, fmt.Errorf("connect: %w", err)
 	}
 
 	defer resp.Body.Close()
 
-	if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
-		log.Printf("error reading response from %v: %v", domain, err)
-		e.status.WithLabelValues("http", domain).Set(0)
-		return
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		return res, fmt.Errorf("read the response: %w", err)
 	}
 
-	cert := resp.TLS.PeerCertificates[0]
+	// A target that redirects to plain HTTP gives a response with no TLS
+	// state. Reading the certificate here would stop the exporter.
+	if resp.TLS == nil {
+		return res, errNoTLS
+	}
+	if len(resp.TLS.PeerCertificates) == 0 {
+		return res, errNoPeerCertificate
+	}
 
-	e.certificates.WithLabelValues("http", domain).Set(
-		float64(time.Until(cert.NotAfter)/time.Hour) / 24,
-	)
+	res.up = true
+	res.notAfter = resp.TLS.PeerCertificates[0].NotAfter
 
-	e.status.WithLabelValues("http", domain).Set(1)
-
+	return res, nil
 }
 
-func (e *Exporter) collectSMTPDomain(smtpTarget smtpTarget) {
+func probeSMTP(target smtpTarget, timeout time.Duration) (result, error) {
 
-	domain := smtpTarget.domain
+	res := result{probeType: "smtp", domain: target.domain}
 
-	target := net.JoinHostPort(domain, strconv.Itoa(smtpTarget.port))
+	address := net.JoinHostPort(target.domain, strconv.Itoa(target.port))
 
 	start := time.Now()
 
-	conn, err := net.DialTimeout("tcp", target, *timeout)
+	conn, err := net.DialTimeout("tcp", address, timeout)
 	if err != nil {
-		log.Printf("error connecting to smtp server %v: %v", target, err)
-		e.status.WithLabelValues("smtp", domain).Set(0)
-		return
+		return res, fmt.Errorf("connect to %s: %w", address, err)
 	}
 
 	// Close the connection on every path. smtp.NewClient takes it over only
 	// when it succeeds, and Quit does not run when it fails.
 	defer conn.Close()
 
-	conn.SetDeadline(start.Add(*timeout))
-
-	c, err := smtp.NewClient(conn, domain)
-	if err != nil {
-		log.Printf("error collecting %v: %v", target, err)
-		e.status.WithLabelValues("smtp", domain).Set(0)
-		return
+	if err := conn.SetDeadline(start.Add(timeout)); err != nil {
+		return res, fmt.Errorf("set the deadline for %s: %w", address, err)
 	}
 
-	defer c.Quit()
-
-	err = c.StartTLS(smtpTarget.tls)
+	client, err := smtp.NewClient(conn, target.domain)
 	if err != nil {
-		log.Printf("STARTTLS handshake failed for %v: %v", target, err)
-		e.status.WithLabelValues("smtp", domain).Set(0)
-		return
+		return res, fmt.Errorf("start the session with %s: %w", address, err)
 	}
 
-	state, ok := c.TLSConnectionState()
+	defer client.Quit()
+
+	if err := client.StartTLS(target.tls); err != nil {
+		return res, fmt.Errorf("STARTTLS with %s: %w", address, err)
+	}
+
+	state, ok := client.TLSConnectionState()
 	if !ok {
-		log.Printf("couldn't get TLS state from %v", target)
-		e.status.WithLabelValues("smtp", domain).Set(0)
-		return
+		return res, fmt.Errorf("%s: %w", address, errNoTLS)
+	}
+	if len(state.PeerCertificates) == 0 {
+		return res, fmt.Errorf("%s: %w", address, errNoPeerCertificate)
 	}
 
-	cert := state.PeerCertificates[0]
+	res.up = true
+	res.notAfter = state.PeerCertificates[0].NotAfter
 
-	e.certificates.WithLabelValues("smtp", domain).Set(
-		float64(time.Until(cert.NotAfter)/time.Hour) / 24,
-	)
-
-	e.status.WithLabelValues("smtp", domain).Set(1)
-
+	return res, nil
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -68,18 +68,18 @@ func TestNewHTTPClientPerTarget(t *testing.T) {
 // detector reports the shared-client fault here, because every probe runs in
 // its own goroutine.
 func TestCollectConcurrentTargets(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		}))
-	defer server.Close()
-
-	host := strings.TrimPrefix(server.URL, "https://")
-
+	// One server for each target. Two targets cannot share a domain, because
+	// the metrics of one scrape would then carry the same labels twice.
 	config := &Config{}
 	for i := 0; i < 8; i++ {
+		server := httptest.NewTLSServer(http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+		defer server.Close()
+
 		config.HTTPDomains = append(config.HTTPDomains, HTTPDomain{
-			Domain: host,
+			Domain: strings.TrimPrefix(server.URL, "https://"),
 			// The certificate of the test server names 127.0.0.1, not the
 			// host and port that the probe sends as the server name.
 			InsecureSkipVerify: true,
@@ -114,23 +114,22 @@ func TestCollectConcurrentTargets(t *testing.T) {
 		t.Fatalf("Gather: %v", err)
 	}
 
-	var up float64
-	var found bool
+	var count int
 	for _, family := range families {
 		if family.GetName() != "ssl_endpoint_up" {
 			continue
 		}
 		for _, metric := range family.GetMetric() {
-			found = true
-			up = metric.GetGauge().GetValue()
+			count++
+			if up := metric.GetGauge().GetValue(); up != 1 {
+				t.Errorf("ssl_endpoint_up for %v: got %v, want 1",
+					metric.GetLabel(), up)
+			}
 		}
 	}
 
-	if !found {
-		t.Fatal("ssl_endpoint_up is not in the gathered metrics")
-	}
-	if up != 1 {
-		t.Errorf("ssl_endpoint_up: got %v, want 1", up)
+	if count != 8 {
+		t.Errorf("ssl_endpoint_up series: got %d, want 8", count)
 	}
 }
 


### PR DESCRIPTION
The collector now builds the metrics of each scrape instead of holding
them between scrapes.

## The fault

The collector held two `GaugeVec` values and wrote into them on every
probe. A gauge keeps its value until something writes again:

- A probe that failed left the last good expiry in the output.
  `ssl_endpoint_up` dropped to 0, and `ssl_certificate_days_left` kept
  counting down from the last good scrape. An alert on the expiry then
  read a value that no probe had confirmed.
- A target that left the configuration kept its series until a restart.

The collector now builds the metrics with `MustNewConstMetric`, from the
results of that scrape only. A probe that fails reports
`ssl_endpoint_up 0` and no expiry.

## The panic

The HTTP probe read the certificate without a check:

```go
cert := resp.TLS.PeerCertificates[0]
```

`resp.TLS` is nil when the target redirects from HTTPS to plain HTTP,
because the client follows the redirect and the last response has no TLS
state. Reading the field stopped the whole exporter: the probe runs in a
goroutine, and nothing recovers.

The probe now reports the target as down for a response with no TLS
state, and for a state with an empty certificate chain.

## A new check on the configuration

Two targets of the same type with the same domain are now an error at
startup.

The metrics carry the labels `type` and `domain` only. Two such targets
give two series with the same labels, and a registry rejects that: the
whole `/metrics` output fails, not one target. The `GaugeVec` merged them
without a word, so this check keeps a working configuration working and
stops a broken one at startup instead of at the first scrape.

The same domain under `[[http_domains]]` and `[[smtp_domains]]` is still
correct, because the `type` label differs.

## Other changes

- The probes are functions that return a result and an error, so a test
  can call them without a registry.
- The timeout comes from the `Exporter`, not from the flag variable.
- Use `io.Discard`. `io/ioutil` is deprecated.
- Report the days left as an exact value. The old code divided a whole
  number of hours, which cut the value down to the hour. An alert on
  `< 21` behaves the same.

## Tests

- `TestExpiryLeavesTheOutputWhenTheProbeFails` scrapes a target, closes
  it, and scrapes again. The expiry must leave the output.
- `TestRedirectToPlainHTTP` points a target at an HTTPS server that
  redirects to plain HTTP. This is the case that stopped the exporter.
- `TestTargetLeavesTheOutput` gathers from an exporter with no target and
  wants no series at all.
- `TestDaysLeft` covers whole days, half days, and a certificate that
  ended.
- `TestDescribeNamesBothMetrics` keeps the registry able to find the
  metrics before the first scrape.

