### PR TITLE
ci: add golangci-lint to the lint job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,3 +58,5 @@ jobs:
 
       - name: Run go vet
         run: go vet ./...
+
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0

--- a/config.go
+++ b/config.go
@@ -65,7 +65,9 @@ func LoadConfig(path string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open the configuration file %s: %w", path, err)
 	}
-	defer f.Close()
+	// The file is open for reading only, so a close error says nothing that
+	// the caller can act on.
+	defer func() { _ = f.Close() }()
 
 	var config Config
 	if err := toml.NewDecoder(f).Decode(&config); err != nil {

--- a/main.go
+++ b/main.go
@@ -223,7 +223,9 @@ func probeHTTP(target httpTarget) (result, error) {
 		return res, fmt.Errorf("connect: %w", err)
 	}
 
-	defer resp.Body.Close()
+	// The body is read only, so a close error says nothing about the
+	// certificate that the probe came for.
+	defer func() { _ = resp.Body.Close() }()
 
 	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 		return res, fmt.Errorf("read the response: %w", err)
@@ -261,8 +263,10 @@ func probeSMTP(target smtpTarget, timeout time.Duration) (result, error) {
 	}
 
 	// Close the connection on every path. smtp.NewClient takes it over only
-	// when it succeeds, and Quit does not run when it fails.
-	defer conn.Close()
+	// when it succeeds, and Quit does not run when it fails. A close error
+	// after a finished probe changes nothing, and Quit closes first on the
+	// path where it runs.
+	defer func() { _ = conn.Close() }()
 
 	if err := conn.SetDeadline(start.Add(timeout)); err != nil {
 		return res, fmt.Errorf("set the deadline for %s: %w", address, err)
@@ -273,7 +277,10 @@ func probeSMTP(target smtpTarget, timeout time.Duration) (result, error) {
 		return res, fmt.Errorf("start the session with %s: %w", address, err)
 	}
 
-	defer client.Quit()
+	// QUIT is a courtesy to the mail server. The probe already has the
+	// certificate by the time this runs, so a failure here is not a failure
+	// of the probe.
+	defer func() { _ = client.Quit() }()
 
 	if err := client.StartTLS(target.tls); err != nil {
 		return res, fmt.Errorf("STARTTLS with %s: %w", address, err)


### PR DESCRIPTION
The lint job now runs `golangci-lint`.

## Why it was not there

The workflow that came back with the build left `golangci-lint` out,
because it failed on the code as it was then: unchecked errors, a shared
client, `io/ioutil`, and a certificate read with no check. A red check on
a repository with no working pipeline helps nobody, so the linter waited
for the code.

## What it found

Four issues, all of them `errcheck`:

```
config.go:68  Error return value of `f.Close` is not checked
main.go:226   Error return value of `resp.Body.Close` is not checked
main.go:265   Error return value of `conn.Close` is not checked
main.go:276   Error return value of `client.Quit` is not checked
```

Each one is a deferred close that the caller cannot act on:

- The configuration file is open for reading.
- The response body is open for reading, and the probe already has the
  certificate.
- The connection carries a probe that finished.
- `QUIT` is a courtesy to the mail server, after the probe has what it
  came for.

They now read `defer func() { _ = x.Close() }()`, with a comment on each
that says why. The suppression sits in the code, where the next reader
meets it, and not in a configuration file that hides it.

## Configuration

There is no `.golangci.yml`. The linter runs with its own defaults
(`errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`), as it does
in the [vanguard](https://github.com/chrj/vanguard) repository. A
configuration file can come later, with a reason for each linter that it
adds.

The action is pinned to the same commit as the other actions in this
workflow.

## Result

```
$ golangci-lint run ./...
0 issues.
```
