### PR TITLE
build: read the configuration with BurntSushi/toml

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,9 +5,11 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"log"
 	"os"
+	"strings"
 
-	"github.com/naoina/toml"
+	"github.com/BurntSushi/toml"
 )
 
 // errNoCertificate reports a CA file that holds no PEM certificate.
@@ -61,17 +63,24 @@ type Config struct {
 
 // LoadConfig reads and checks the configuration file at path.
 func LoadConfig(path string) (*Config, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("open the configuration file %s: %w", path, err)
-	}
-	// The file is open for reading only, so a close error says nothing that
-	// the caller can act on.
-	defer func() { _ = f.Close() }()
-
 	var config Config
-	if err := toml.NewDecoder(f).Decode(&config); err != nil {
-		return nil, fmt.Errorf("parse the configuration file %s: %w", path, err)
+
+	meta, err := toml.DecodeFile(path, &config)
+	if err != nil {
+		return nil, fmt.Errorf("read the configuration file %s: %w", path, err)
+	}
+
+	// A key that no field matches is almost always a spelling mistake. The
+	// exporter keeps running with the default for that key, so say which key
+	// it was. A wrong "ca_file" would otherwise send the probe to the system
+	// pool without a word.
+	if undecoded := meta.Undecoded(); len(undecoded) > 0 {
+		keys := make([]string, 0, len(undecoded))
+		for _, key := range undecoded {
+			keys = append(keys, key.String())
+		}
+		log.Printf("configuration file %s: no setting matches these keys: %s",
+			path, strings.Join(keys, ", "))
 	}
 
 	if err := config.Validate(); err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -8,9 +9,11 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"log"
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -144,6 +147,44 @@ func TestLoadConfigOldFormat(t *testing.T) {
 	}
 	if config.ServerTLS.Enabled() {
 		t.Error("ServerTLS.Enabled(): got true, want false")
+	}
+}
+
+// TestLoadConfigReportsUnknownKeys covers the spelling mistake that used to
+// pass without a word. The exporter keeps running with the defaults, and it
+// names every key that no field matches.
+func TestLoadConfigReportsUnknownKeys(t *testing.T) {
+	content := `
+listen_port = 9203
+
+[[http_domains]]
+  domain = "www.example.com"
+  cafile = "/etc/ssl/certs/internal-ca.pem"
+`
+
+	var logged bytes.Buffer
+	log.SetOutput(&logged)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	config, err := LoadConfig(writeFile(t, "checks.toml", content))
+	if err != nil {
+		t.Fatalf("LoadConfig returned an error: %v", err)
+	}
+
+	// The good keys still load.
+	if len(config.HTTPDomains) != 1 || config.HTTPDomains[0].Domain != "www.example.com" {
+		t.Errorf("http_domains: got %+v, want one entry for www.example.com", config.HTTPDomains)
+	}
+	// The wrong key does not reach the field that it looks like.
+	if got := config.HTTPDomains[0].CAFile; got != "" {
+		t.Errorf("http_domains[0].ca_file: got %q, want it empty", got)
+	}
+
+	output := logged.String()
+	for _, key := range []string{"cafile", "listen_port"} {
+		if !strings.Contains(output, key) {
+			t.Errorf("the log does not name %q: %s", key, output)
+		}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/chrj/prometheus-ssl-exporter
 go 1.26
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/chrj/smtpd/v2 v2.1.2
-	github.com/naoina/toml v0.1.1
 	github.com/prometheus/client_golang v1.17.0
 )
 
@@ -14,9 +14,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
@@ -13,14 +15,8 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
-github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/naoina/go-stringutil v0.1.0 h1:rCUeRUHjBjGTSHl0VC00jUPLz8/F9dDzYI70Hzifhks=
-github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
-github.com/naoina/toml v0.1.1 h1:PT/lllxVVN0gzzSqSlHEmP8MJB4MY2U7STGxiouV4X8=
-github.com/naoina/toml v0.1.1/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/prometheus/client_golang v1.17.0 h1:rl2sfwZMtSthVU752MqfjQozy7blglC+1SOtjMAMh+Q=
 github.com/prometheus/client_golang v1.17.0/go.mod h1:VeL+gMmOAxkS2IqfCq0ZmHSL+LjWfWDUmp1mBz9JgUY=
 github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 h1:v7DLqVdK4VrYkVD5diGdl4sxJurKJEMnODWRJlxV9oM=


### PR DESCRIPTION
The exporter reads its configuration with
`github.com/BurntSushi/toml` instead of `github.com/naoina/toml`.

## Why

`naoina/toml` had its last release in 2017 and takes no more changes. The
[vanguard](https://github.com/chrj/vanguard) exporter already reads TOML
with `BurntSushi/toml`, so this brings the two repositories together on
one library.

## Compatibility

The struct tags do not change, and the file format does not change. An
existing configuration file keeps working, and
`TestLoadConfigOldFormat` covers that.

## A key that no field matches

`BurntSushi/toml` reports the keys that it read but could not place, so
`LoadConfig` now names them:

```
configuration file /etc/ssl/checks: no setting matches these keys: listen_port, http_domains.cafile
```

A spelling mistake such as `cafile` for `ca_file` used to pass without a
word. The probe then went to the system certificate pool, and a target
behind a private authority reported as down for a reason that the
operator could not see in the file.

The exporter still starts. A key that it does not know is not a reason to
stop a monitor that is otherwise correct, and a message names the key.

`TestLoadConfigReportsUnknownKeys` covers the message, and it also checks
that the wrong key does not reach the field that it looks like.

## Dependencies

`BurntSushi/toml` replaces `naoina/toml`. The swap also drops
`naoina/go-stringutil` and `kylelemons/godebug`, which came in with the
old library.
