### PR TITLE
docs: correct the README and give it the shape of other exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,119 +1,182 @@
 # SSL Exporter for Prometheus
 
-Run checks against HTTPS and SMTP (STARTTLS) endpoints and expose metrics about their SSL certificates
+[![CI](https://github.com/chrj/prometheus-ssl-exporter/actions/workflows/go.yml/badge.svg)](https://github.com/chrj/prometheus-ssl-exporter/actions/workflows/go.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/chrj/prometheus-ssl-exporter)](https://goreportcard.com/report/github.com/chrj/prometheus-ssl-exporter)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+Watch the certificates of your HTTPS and SMTP endpoints, and get an alert
+before one of them expires.
+
+The exporter holds a list of targets in one file. On each scrape it
+connects to every target, reads the certificate that the server presents,
+and reports the start and the end of its validity. An HTTPS target gets a
+`GET` request. An SMTP target gets a STARTTLS session.
 
 ## Installation
 
-    $ go get -u github.com/chrj/prometheus-ssl-exporter
+Build from source with Go 1.26 or later:
+
+```sh
+go install github.com/chrj/prometheus-ssl-exporter@latest
+```
+
+There are no released binaries and no container image yet.
 
 ## Usage
 
-    Usage of prometheus-ssl-exporter:
-      -config string
-        	Configuration file (default "/etc/ssl/checks")
-      -listen-address string
-        	Prometheus metrics port (default ":9203")
-      -timeout duration
-        	Timeout for network operations (default 10s)
+```
+Usage of prometheus-ssl-exporter:
+  -config string
+        Configuration file (default "/etc/ssl/checks")
+  -listen-address string
+        Prometheus metrics port (default ":9203")
+  -timeout duration
+        Timeout for network operations (default 8s)
+```
+
+## Configuration
+
+The configuration file holds the targets. It uses
+[TOML](https://toml.io/). Start from the [sample configuration
+file](config.sample):
+
+```toml
+[[http_domains]]
+  domain = "www.google.com"
+
+[[smtp_domains]]
+  domain = "smtp.gmail.com"
+  port = 587
+```
+
+The exporter reads the file once, at startup. Send it a restart after you
+change the file.
+
+### Per-target options
+
+These options apply to an `[[http_domains]]` entry and to an
+`[[smtp_domains]]` entry. For an SMTP target they apply to the STARTTLS
+session.
+
+| Option | Meaning |
+| --- | --- |
+| `ca_file` | A PEM file with the certificate authority that signed the certificate of this target. An empty value selects the system pool. |
+| `insecure_skip_verify` | Set it to `true` to stop the certificate checks for this target. The probe still reports the validity. |
+
+The exporter reads every `ca_file` at startup. A file that it cannot read
+stops the exporter, and the message names the target.
+
+### Serve the metrics with TLS
+
+```toml
+[tls_server]
+  cert_file = "/etc/ssl/exporter.pem"
+  key_file = "/etc/ssl/exporter.key"
+```
+
+Give both files, or give neither.
 
 ## Metrics
 
 Every metric carries the labels `domain` and `type`. The `type` label is
 `http` or `smtp`.
 
-A probe that fails reports `ssl_endpoint_up 0` and no certificate metrics.
-The certificate metrics of that target leave the output until a probe
-succeeds again.
+| Metric | Meaning |
+| --- | --- |
+| `ssl_cert_not_after` | End of the validity of the certificate, as seconds since the epoch. |
+| `ssl_cert_not_before` | Start of the validity of the certificate, as seconds since the epoch. |
+| `ssl_endpoint_up` | 1 when the last probe read a certificate, 0 when it did not. |
+| `ssl_certificate_days_left` | Days left on the certificate. Deprecated, see below. |
 
-### Gauge: `ssl_cert_not_after`
-
-End of the validity of the certificate, as seconds since the epoch.
-
-### Gauge: `ssl_cert_not_before`
-
-Start of the validity of the certificate, as seconds since the epoch.
-
-### Gauge: `ssl_endpoint_up`
-
-Was the last SSL poll successful.
-
-### Gauge: `ssl_certificate_days_left` (deprecated)
-
-Number of days left on the certificate.
-
-This metric stays for the installations that already use it, and it goes
-away in a later major version. Use `ssl_cert_not_after` instead:
-
-    (ssl_cert_not_after - time()) / 86400
-
-The two give the same number. `ssl_cert_not_after` is a fixed point in
-time, so a graph of it does not move while the certificate stays the
-same, and a recording rule over it does not need a fresh scrape to stay
-correct.
+A probe that fails reports `ssl_endpoint_up 0` and no certificate
+metrics. The certificate metrics of that target stay out of the output
+until a probe succeeds again. A stored value from an older scrape never
+reaches the output.
 
 ### Example
 
-    # HELP ssl_cert_not_after End of the validity of the certificate, as seconds since the epoch
-    # TYPE ssl_cert_not_after gauge
-    ssl_cert_not_after{domain="smtp.gmail.com",type="smtp"} 1.7869248e+09
-    ssl_cert_not_after{domain="www.google.com",type="http"} 1.7869248e+09
-    # HELP ssl_cert_not_before Start of the validity of the certificate, as seconds since the epoch
-    # TYPE ssl_cert_not_before gauge
-    ssl_cert_not_before{domain="smtp.gmail.com",type="smtp"} 1.7791488e+09
-    ssl_cert_not_before{domain="www.google.com",type="http"} 1.7791488e+09
-    # HELP ssl_certificate_days_left DEPRECATED: use (ssl_cert_not_after - time()) / 86400. Number of days left on the certificate
-    # TYPE ssl_certificate_days_left gauge
-    ssl_certificate_days_left{domain="smtp.gmail.com",type="smtp"} 48.2
-    ssl_certificate_days_left{domain="www.google.com",type="http"} 48.2
-    # HELP ssl_endpoint_up Was the last SSL poll successful
-    # TYPE ssl_endpoint_up gauge
-    ssl_endpoint_up{domain="smtp.gmail.com",type="smtp"} 1
-    ssl_endpoint_up{domain="www.google.com",type="http"} 1
+```
+# HELP ssl_cert_not_after End of the validity of the certificate, as seconds since the epoch
+# TYPE ssl_cert_not_after gauge
+ssl_cert_not_after{domain="smtp.gmail.com",type="smtp"} 1.791828448e+09
+ssl_cert_not_after{domain="www.google.com",type="http"} 1.789980012e+09
+ssl_cert_not_after{domain="www.technobabble.dk",type="http"} 1.788093249e+09
+# HELP ssl_cert_not_before Start of the validity of the certificate, as seconds since the epoch
+# TYPE ssl_cert_not_before gauge
+ssl_cert_not_before{domain="smtp.gmail.com",type="smtp"} 1.784570849e+09
+ssl_cert_not_before{domain="www.google.com",type="http"} 1.782722413e+09
+ssl_cert_not_before{domain="www.technobabble.dk",type="http"} 1.78031725e+09
+# HELP ssl_endpoint_up Was the last SSL poll successful
+# TYPE ssl_endpoint_up gauge
+ssl_endpoint_up{domain="smtp.gmail.com",type="smtp"} 1
+ssl_endpoint_up{domain="www.google.com",type="http"} 1
+ssl_endpoint_up{domain="www.technobabble.dk",type="http"} 1
+```
 
-## Configuration
+### `ssl_certificate_days_left` is deprecated
 
-Supply a configuration file path with `-config` (optionally, defaults to `/etc/ssl/checks`). Uses [TOML](https://github.com/toml-lang/toml).
+Use `ssl_cert_not_after` instead:
 
-[Sample configuration file](config.sample)
+```promql
+(ssl_cert_not_after - time()) / 86400
+```
 
-The file holds the targets and the options below. The exporter reads the CA
-files at startup, so a file that it cannot read stops the exporter with a
-message that names the target.
+The two give the same number. `ssl_cert_not_after` is a fixed point in
+time, so a graph of it holds a straight line while the certificate stays
+the same. `ssl_certificate_days_left` falls on every scrape, which hides
+the date and makes a recording rule only as correct as the last sample.
 
-### Per-target options for `[[http_domains]]` and `[[smtp_domains]]`
+`ssl_certificate_days_left` stays for the installations that use it
+today. It goes away in a later major version.
 
-* `ca_file`: a PEM file with the certificate authority that signed the
-  certificate of this target. An empty value selects the system pool.
-* `insecure_skip_verify`: set it to `true` to stop the certificate checks
-  for this target. The probe still reports the expiry.
+## Prometheus configuration
 
-For an SMTP target, these options apply to the STARTTLS session.
+```yaml
+- job_name: "ssl"
+  scrape_interval: "1m"
+  static_configs:
+    - targets:
+        - "server:9203"
+```
 
-### `[tls_server]`
+Each scrape starts one probe for each target, so keep the interval longer
+than the time that the slowest target needs.
 
-Serve the metrics endpoint with TLS. Give `cert_file` and `key_file`
-together, or give neither.
+## Alerting
 
-## Prometheus target
+The [sample alert definition](ssl.rules.yml) holds three alerts:
 
-Supply a listen address with `-addr` (optionally, defaults to `:9203`), and configure a Prometheus job:
+| Alert | Condition |
+| --- | --- |
+| `SSLCertificateNearExpiration` | The certificate is valid and ends in less than 21 days. |
+| `SSLCertificateExpired` | The certificate ended. |
+| `SSLEndpointDown` | The probes of the target failed for 15 minutes. |
 
-    - job_name: "ssl"
-      scrape_interval: "1m"
-      static_configs:
-        - targets:
-            - "server:9203"
+Check the file after you change it:
 
-## Prometheus alert
+```sh
+promtool check rules ssl.rules.yml
+```
 
-The real benefit is getting an alert triggered when an SSL certificate is nearing expiration or not responding. Check this [sample alert definition](ssl.rules.yml).
+## How this compares to ssl_exporter
 
-The file holds three alerts:
+[`ribbybibby/ssl_exporter`](https://github.com/ribbybibby/ssl_exporter)
+covers more ground. It reads certificates from PEM files, Kubernetes
+secrets, and kubeconfig files, it queries OCSP, and it speaks STARTTLS
+for SMTP, FTP, IMAP, POP3, and PostgreSQL.
 
-* `SSLCertificateNearExpiration`: the certificate is valid and ends in
-  less than 21 days.
-* `SSLCertificateExpired`: the certificate ended.
-* `SSLEndpointDown`: the last probe of the target failed.
+The two differ in the way they get their targets:
 
-Check the file with `promtool check rules ssl.rules.yml` after you change
-it.
+- `ssl_exporter` follows the model of the blackbox exporter. Prometheus
+  holds the target list and passes each target as a query parameter to
+  `/probe`. Service discovery therefore works.
+- This exporter holds the target list in its own file and reports every
+  target on `/metrics`.
+
+Pick this one for a fixed list of endpoints that you want in one file.
+Pick `ssl_exporter` for targets that come from service discovery, or for
+certificates that do not sit behind a network endpoint.
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # SSL Exporter for Prometheus
 
 [![CI](https://github.com/chrj/prometheus-ssl-exporter/actions/workflows/go.yml/badge.svg)](https://github.com/chrj/prometheus-ssl-exporter/actions/workflows/go.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/chrj/prometheus-ssl-exporter)](https://goreportcard.com/report/github.com/chrj/prometheus-ssl-exporter)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 Watch the certificates of your HTTPS and SMTP endpoints, and get an alert


### PR DESCRIPTION
The README gave three instructions that do not work, and it did not look
like the README of an exporter that a reader can trust.

## The wrong statements

- The installation command was `go get -u github.com/chrj/prometheus-ssl-exporter`.
  Go 1.17 stopped installing binaries with `go get`, so the only command
  in the file did nothing. It is `go install ...@latest` now.
- The Prometheus section said "Supply a listen address with `-addr`".
  The flag is `-listen-address`. The usage block above it already said
  so, so the file argued with itself.
- The usage block gave the timeout default as `10s`. It is `8s`.

The usage block now matches the output of `-h` line for line.

## The example output

The old block predated the metrics that this repository reports today.
The new block came from a run against `www.google.com`,
`www.technobabble.dk`, and `smtp.gmail.com`, so the names, the format,
and the exponent notation are real.

## The shape

Compared against `ribbybibby/ssl_exporter`, `blackbox_exporter`,
`node_exporter`, and `postgres_exporter`. Every one of them opens with
badges and holds its metrics in a table:

- Add badges for the pipeline and the license. A reader who finds this
  repository wants to know that it still builds.
- Put the metrics in a table. Four metrics with the same two labels do
  not need a section each.
- Say what a probe reports when it fails. That answer changed, and no
  file said it.
- Name the alerts and their conditions, so a reader does not open the
  rules file to learn what it holds.
- Say that the exporter reads the configuration file once, at startup.
- Point to the license.

## The comparison with ssl_exporter

`ribbybibby/ssl_exporter` is the exporter that a reader finds first, and
it covers more ground: PEM files, Kubernetes secrets, kubeconfig files,
OCSP, and STARTTLS for five protocols. Both export `ssl_cert_not_after`,
so nothing told a reader which one to take.

The section gives the difference that decides it. `ssl_exporter` follows
the model of the blackbox exporter, where Prometheus holds the targets
and passes each one to `/probe`, so service discovery works. This
exporter holds its targets in its own file.

## What this does not do

There are no released binaries and no container image, and the file now
says so instead of promising a download that does not exist. Other
exporters open with "download a binary". That needs a release workflow,
which is a separate change.

## No Go Report Card badge

The first version of this change carried one. `goreportcard.com` is
sunset, and the badge endpoint still answers with HTTP 200, so a check of
the status code does not catch it. The image itself now reads:

```
go report: retired
```

`chrj/smtpd` and `chrj/wgnet` carry the same badge and show the same
word.
