### PR TITLE
ci: run the push build on main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,16 +1,16 @@
 name: prometheus-ssl-exporter
 
 on:
-  # Only master runs on push. A branch listed here that also has a pull
+  # Only main runs on push. A branch listed here that also has a pull
   # request runs the same commit twice, once for each event.
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:
 
-  # "Build and Test" is the required status check on master. A new name here
+  # "Build and Test" is the required status check on main. A new name here
   # needs a matching change to the branch protection rule.
   build:
     name: Build and Test


### PR DESCRIPTION
The default branch is now `main`. The push trigger still named `master`, so no build ran on a push to the default branch.

This changes the trigger and the two comments that name the branch.