### PR TITLE
fix: give the server timeouts and let a context cancel a probe

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+version: "2"
+
+linters:
+  # These three catch faults that the default set lets through: a server
+  # with no timeouts, network calls that no caller can cancel, and a type
+  # assertion that stops the process.
+  enable:
+    - forcetypeassert
+    - gosec
+    - noctx
+
+  exclusions:
+    rules:
+      # A test listener serves one test and stops with it, so it needs no
+      # context to cancel.
+      - path: _test\.go
+        linters:
+          - noctx

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,5 @@ build:
 run: build
 	@./bin/$(BINARY_NAME)
 
-# run-config: build
-# 	@./bin/$(BINARY_NAME) --exporter-config /path/to/config/exporter.yml
+run-sample: build
+	@./bin/$(BINARY_NAME) -config config.sample

--- a/config.go
+++ b/config.go
@@ -147,8 +147,11 @@ func (c *Config) Validate() error {
 // startup instead of breaking each scrape.
 func TLSConfig(serverName, caFile string, skipVerify bool) (*tls.Config, error) {
 	config := &tls.Config{
-		ServerName:         serverName,
-		InsecureSkipVerify: skipVerify,
+		ServerName: serverName,
+		// The operator turns the checks off for one target, and the probe
+		// then reports the expiry of a certificate that it cannot trust.
+		// That is what the setting is for.
+		InsecureSkipVerify: skipVerify, //nolint:gosec // the operator asks for this per target
 		MinVersion:         tls.VersionTLS12,
 	}
 
@@ -156,7 +159,7 @@ func TLSConfig(serverName, caFile string, skipVerify bool) (*tls.Config, error) 
 		return config, nil
 	}
 
-	pem, err := os.ReadFile(caFile)
+	pem, err := os.ReadFile(caFile) //nolint:gosec // the operator names this file in the configuration
 	if err != nil {
 		return nil, fmt.Errorf("read the CA file: %w", err)
 	}

--- a/exporter.go
+++ b/exporter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -81,13 +82,18 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 	results := make([]result, len(e.httpTargets)+len(e.smtpTargets))
 
+	// The Collector interface carries no context, so the scrape makes its own.
+	// The deadline bounds every probe of this scrape together.
+	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+	defer cancel()
+
 	var wg sync.WaitGroup
 	wg.Add(len(results))
 
 	for i, target := range e.httpTargets {
 		go func(slot int, target httpTarget) {
 			defer wg.Done()
-			results[slot] = e.probe(probeHTTP(target))
+			results[slot] = e.probe(probeHTTP(ctx, target))
 		}(i, target)
 	}
 
@@ -96,7 +102,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	for i, target := range e.smtpTargets {
 		go func(slot int, target smtpTarget) {
 			defer wg.Done()
-			results[slot] = e.probe(probeSMTP(target, e.timeout))
+			results[slot] = e.probe(probeSMTP(ctx, target, e.timeout))
 		}(offset+i, target)
 	}
 

--- a/main.go
+++ b/main.go
@@ -32,14 +32,26 @@ func main() {
 
 	prometheus.MustRegister(exporter)
 
-	http.Handle("/metrics", promhttp.Handler())
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+
+	// The timeouts stop a client that opens a connection and then stalls.
+	// WriteTimeout covers the whole response, so it holds every probe of one
+	// scrape and stays above the timeout for network operations.
+	server := &http.Server{
+		Addr:              *addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      *timeout + 30*time.Second,
+	}
 
 	if config.ServerTLS.Enabled() {
 		log.Printf("starting exporter with TLS on %s", *addr)
-		log.Fatal(http.ListenAndServeTLS(*addr,
-			config.ServerTLS.CertFile, config.ServerTLS.KeyFile, nil))
+		log.Fatal(server.ListenAndServeTLS(
+			config.ServerTLS.CertFile, config.ServerTLS.KeyFile))
 	}
 
 	log.Printf("starting exporter on %s", *addr)
-	log.Fatal(http.ListenAndServe(*addr, nil))
+	log.Fatal(server.ListenAndServe())
 }

--- a/probes.go
+++ b/probes.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -51,7 +52,13 @@ func newHTTPClient(target HTTPDomain, timeout time.Duration) (*http.Client, erro
 		return nil, fmt.Errorf("TLS settings for %s: %w", target.Domain, err)
 	}
 
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("the default HTTP transport is %T, not *http.Transport",
+			http.DefaultTransport)
+	}
+
+	transport := defaultTransport.Clone()
 	transport.TLSClientConfig = tlsConfig
 
 	return &http.Client{
@@ -60,11 +67,12 @@ func newHTTPClient(target HTTPDomain, timeout time.Duration) (*http.Client, erro
 	}, nil
 }
 
-func probeHTTP(target httpTarget) (result, error) {
+func probeHTTP(ctx context.Context, target httpTarget) (result, error) {
 
 	res := result{probeType: "http", domain: target.domain}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/", target.domain), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		fmt.Sprintf("https://%s/", target.domain), nil)
 	if err != nil {
 		return res, fmt.Errorf("build the request: %w", err)
 	}
@@ -101,7 +109,10 @@ func probeHTTP(target httpTarget) (result, error) {
 	return res, nil
 }
 
-func probeSMTP(target smtpTarget, timeout time.Duration) (result, error) {
+// probeSMTP takes both a context and a timeout. The context cancels the dial
+// and gives the deadline of the scrape. The timeout bounds this one session, so
+// the probe still stops when the context carries no deadline.
+func probeSMTP(ctx context.Context, target smtpTarget, timeout time.Duration) (result, error) {
 
 	res := result{probeType: "smtp", domain: target.domain}
 
@@ -109,7 +120,9 @@ func probeSMTP(target smtpTarget, timeout time.Duration) (result, error) {
 
 	start := time.Now()
 
-	conn, err := net.DialTimeout("tcp", address, timeout)
+	dialer := net.Dialer{Timeout: timeout}
+
+	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
 		return res, fmt.Errorf("connect to %s: %w", address, err)
 	}
@@ -120,7 +133,15 @@ func probeSMTP(target smtpTarget, timeout time.Duration) (result, error) {
 	// path where it runs.
 	defer func() { _ = conn.Close() }()
 
-	if err := conn.SetDeadline(start.Add(timeout)); err != nil {
+	// smtp.Client watches no context, so the deadline of the connection is the
+	// only thing that ends the session. Take whichever comes first, so the
+	// deadline of the scrape holds the session as well.
+	deadline := start.Add(timeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+
+	if err := conn.SetDeadline(deadline); err != nil {
 		return res, fmt.Errorf("set the deadline for %s: %w", address, err)
 	}
 

--- a/probes_test.go
+++ b/probes_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -88,7 +89,7 @@ func TestProbeHTTPReadsTheCertificate(t *testing.T) {
 	host := strings.TrimPrefix(server.URL, "https://")
 	leaf := server.Certificate()
 
-	res, err := probeHTTP(newHTTPProbeTarget(t, host))
+	res, err := probeHTTP(t.Context(), newHTTPProbeTarget(t, host))
 	if err != nil {
 		t.Fatalf("probeHTTP: %v", err)
 	}
@@ -128,7 +129,7 @@ func TestProbeHTTPRedirectToPlainHTTP(t *testing.T) {
 
 	host := strings.TrimPrefix(secure.URL, "https://")
 
-	res, err := probeHTTP(newHTTPProbeTarget(t, host))
+	res, err := probeHTTP(t.Context(), newHTTPProbeTarget(t, host))
 	if !errors.Is(err, errNoTLS) {
 		t.Errorf("probeHTTP: got %v, want %v", err, errNoTLS)
 	}
@@ -150,7 +151,7 @@ func TestProbeHTTPKeepsTheLabelsWhenItFails(t *testing.T) {
 	// The target stops answering.
 	server.Close()
 
-	res, err := probeHTTP(target)
+	res, err := probeHTTP(t.Context(), target)
 	if err == nil {
 		t.Fatal("probeHTTP returned no error for a target that does not answer")
 	}
@@ -165,6 +166,70 @@ func TestProbeHTTPKeepsTheLabelsWhenItFails(t *testing.T) {
 	}
 }
 
+// TestProbeHTTPStopsOnACancelledContext cancels a probe that is waiting for a
+// response. Without the context the probe runs to the timeout of its client,
+// so a scrape that the Prometheus server dropped keeps working.
+func TestProbeHTTPStopsOnACancelledContext(t *testing.T) {
+	// The handler holds the response, so only the context ends the probe. It
+	// watches the context of the request as well, so Close does not wait.
+	release := make(chan struct{})
+	server := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case <-release:
+			case <-r.Context().Done():
+			}
+		}))
+	defer server.Close()
+	defer close(release)
+
+	target := newHTTPProbeTarget(t, strings.TrimPrefix(server.URL, "https://"))
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := probeHTTP(ctx, target)
+		done <- err
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		// A client that ignores the context gives a timeout after 3 seconds
+		// instead, which this check does not accept.
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("probeHTTP: got %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("probeHTTP did not return after the context was cancelled")
+	}
+}
+
+// TestProbeSMTPStopsOnACancelledContext makes sure that the context reaches
+// the dial of an SMTP probe.
+func TestProbeSMTPStopsOnACancelledContext(t *testing.T) {
+	ca := newTestCA(t)
+	port := startSMTPServer(t, ca.ServerCert)
+
+	tlsConfig, err := TLSConfig("localhost", ca.CAFile, false)
+	if err != nil {
+		t.Fatalf("TLSConfig: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	res, err := probeSMTP(ctx, smtpTarget{domain: "localhost", port: port, tls: tlsConfig}, 5*time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("probeSMTP: got %v, want %v", err, context.Canceled)
+	}
+	if res.up {
+		t.Error("up: got true, want false")
+	}
+}
+
 // TestProbeSMTPRejectsAnUntrustedCertificate names the STARTTLS failure for a
 // server whose authority the probe does not hold.
 func TestProbeSMTPRejectsAnUntrustedCertificate(t *testing.T) {
@@ -176,7 +241,7 @@ func TestProbeSMTPRejectsAnUntrustedCertificate(t *testing.T) {
 		t.Fatalf("TLSConfig: %v", err)
 	}
 
-	res, err := probeSMTP(smtpTarget{domain: "localhost", port: port, tls: tlsConfig}, 5*time.Second)
+	res, err := probeSMTP(t.Context(), smtpTarget{domain: "localhost", port: port, tls: tlsConfig}, 5*time.Second)
 	if err == nil {
 		t.Fatal("probeSMTP returned no error for an untrusted certificate")
 	}
@@ -202,7 +267,7 @@ func TestProbeSMTPReadsTheCertificate(t *testing.T) {
 		t.Fatalf("TLSConfig: %v", err)
 	}
 
-	res, err := probeSMTP(smtpTarget{domain: "localhost", port: port, tls: tlsConfig}, 5*time.Second)
+	res, err := probeSMTP(t.Context(), smtpTarget{domain: "localhost", port: port, tls: tlsConfig}, 5*time.Second)
 	if err != nil {
 		t.Fatalf("probeSMTP: %v", err)
 	}


### PR DESCRIPTION
Four things I wanted to address to bring this codebase up to speed.

## `ci:` enable gosec, noctx and forcetypeassert

The repository had no `.golangci.yml`, so CI ran the default set of linters. `gosec`, `noctx` and `forcetypeassert` are not in that set, which is why the three faults below passed CI.

Two gosec reports are by design and now carry a reason:

- `InsecureSkipVerify` is a documented per-target option.
- The path of the CA file comes from the configuration of the operator.

`noctx` is off for test files. A test listener serves one test and stops with it.

## `build:` correct the run target

The commented-out target named `--exporter-config /path/to/config/exporter.yml`. The flag is `-config` and the format is TOML, so both parts were wrong. It is now `make run-sample`, and it works.

## `fix:` give the metrics server timeouts

`http.ListenAndServe(*addr, nil)` used the zero value of `http.Server`: no `ReadHeaderTimeout`, no `ReadTimeout`, no `WriteTimeout`. One client that opened a connection and then sent nothing held a goroutine for as long as it liked.

I sent incomplete headers to the old build and to the new one. The old build held the connection open with no end. The new build closes it after 5 seconds.

`WriteTimeout` is the timeout for network operations plus 30 seconds, so it holds every probe of one scrape.

The handler goes on its own mux, because the server needs an explicit handler. `/metrics` still carries the `go_` and `process_` metrics, which I checked against a running build.

## `fix:` let a context cancel a probe

`probeHTTP` called `http.NewRequest` and `probeSMTP` called `net.DialTimeout`. Neither took a context, so nothing could stop a probe early. A scrape that the Prometheus server gave up on kept running to the timeout of each client.

`Collect` now makes a context for the scrape and both probes take it. The SMTP session takes the deadline of the scrape when that comes first, because `smtp.Client` watches no context and only the deadline of the connection ends the session.

Two tests cover this. I ran both against the old behaviour first:

- `probeHTTP` returned a client timeout after 3 seconds instead of `context.Canceled`.
- `probeSMTP` ignored the cancelled context and reported the target as up.

Both now return `context.Canceled` at once.

The commit also puts a check on the type assertion in `newHTTPClient`. `http.DefaultTransport.(*http.Transport)` stopped the process on a transport it did not expect.

## Tests

27 tests, up from 25. Coverage is 84.6%, and `main` is the only function at zero. `go vet` and `golangci-lint run ./...` report nothing with the new configuration. The race detector does not run in my sandbox, so CI is the first `go test -race` of this branch.