### PR TITLE
fix: give the probes the context of the scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ today. It goes away in a later major version.
 Each scrape starts one probe for each target, so keep the interval longer
 than the time that the slowest target needs.
 
+The exporter stops the probes of a scrape when Prometheus gives up on that
+scrape. Keep `scrape_timeout` longer than `-timeout`. A scrape that ends
+early reports no metrics at all, for any target.
+
 ## Alerting
 
 The [sample alert definition](ssl.rules.yml) holds three alerts:

--- a/collect_test.go
+++ b/collect_test.go
@@ -46,7 +46,7 @@ func registerTarget(t *testing.T, host string) *prometheus.Registry {
 	}
 
 	registry := prometheus.NewPedanticRegistry()
-	if err := registry.Register(exporter); err != nil {
+	if err := registry.Register(exporter.newScrape(t.Context())); err != nil {
 		t.Fatalf("register the exporter: %v", err)
 	}
 
@@ -139,7 +139,7 @@ func TestTargetLeavesTheOutput(t *testing.T) {
 		t.Fatalf("NewSSLExporter: %v", err)
 	}
 	registry := prometheus.NewPedanticRegistry()
-	if err := registry.Register(empty); err != nil {
+	if err := registry.Register(empty.newScrape(t.Context())); err != nil {
 		t.Fatalf("register the exporter: %v", err)
 	}
 

--- a/exporter.go
+++ b/exporter.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -74,18 +76,57 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- certDaysLeftDesc
 }
 
-// Collect probes every target and writes the metrics of this scrape. It
+// scrape is the collector for one request. It holds a context, which a
+// collector cannot take as an argument, so the probes of one scrape stop when
+// the server that asked for them goes away.
+type scrape struct {
+	exporter *Exporter
+	ctx      context.Context
+}
+
+// newScrape gives the collector for one scrape.
+func (e *Exporter) newScrape(ctx context.Context) scrape {
+	return scrape{exporter: e, ctx: ctx}
+}
+
+func (s scrape) Describe(ch chan<- *prometheus.Desc) {
+	s.exporter.Describe(ch)
+}
+
+func (s scrape) Collect(ch chan<- prometheus.Metric) {
+	s.exporter.collect(s.ctx, ch)
+}
+
+// Handler serves the metrics. It builds a registry for each request, because
+// only a collector made for that request can carry its context.
+func (e *Exporter) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), e.timeout)
+		defer cancel()
+
+		registry := prometheus.NewRegistry()
+		if err := registry.Register(e.newScrape(ctx)); err != nil {
+			log.Printf("register the collector for a scrape: %v", err)
+			http.Error(w, "the exporter could not build the metrics for this scrape",
+				http.StatusInternalServerError)
+			return
+		}
+
+		// The default gatherer holds the go_ and process_ metrics, which the
+		// registry of this request does not.
+		gatherers := prometheus.Gatherers{prometheus.DefaultGatherer, registry}
+
+		promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+	})
+}
+
+// collect probes every target and writes the metrics of this scrape. It
 // builds the metrics from the results of this scrape only, so a target that
 // leaves the configuration leaves the output, and a probe that fails reports
 // no expiry.
-func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
+func (e *Exporter) collect(ctx context.Context, ch chan<- prometheus.Metric) {
 
 	results := make([]result, len(e.httpTargets)+len(e.smtpTargets))
-
-	// The Collector interface carries no context, so the scrape makes its own.
-	// The deadline bounds every probe of this scrape together.
-	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
-	defer cancel()
 
 	var wg sync.WaitGroup
 	wg.Add(len(results))

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +12,114 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+// TestHandlerServesBothRegistries makes sure that one scrape carries the
+// metrics of the exporter and the metrics of the process. The exporter builds
+// a registry for each request, and only the default one holds go_ and
+// process_.
+func TestHandlerServesBothRegistries(t *testing.T) {
+	target := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+	defer target.Close()
+
+	exporter, err := NewSSLExporter(&Config{
+		HTTPDomains: []HTTPDomain{{
+			Domain:             strings.TrimPrefix(target.URL, "https://"),
+			InsecureSkipVerify: true,
+		}},
+	}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("NewSSLExporter: %v", err)
+	}
+
+	metrics := httptest.NewServer(exporter.Handler())
+	defer metrics.Close()
+
+	// Two scrapes, because a registry that the handler keeps between requests
+	// would fail the second one.
+	for _, scrapeNumber := range []int{1, 2} {
+		resp, err := metrics.Client().Get(metrics.URL)
+		if err != nil {
+			t.Fatalf("scrape %d: %v", scrapeNumber, err)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("scrape %d: read the body: %v", scrapeNumber, err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			t.Fatalf("scrape %d: close the body: %v", scrapeNumber, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("scrape %d status: got %d, want %d",
+				scrapeNumber, resp.StatusCode, http.StatusOK)
+		}
+
+		for _, name := range []string{"ssl_endpoint_up", "ssl_cert_not_after", "go_goroutines"} {
+			if !strings.Contains(string(body), name) {
+				t.Errorf("scrape %d: %s is not in the output", scrapeNumber, name)
+			}
+		}
+	}
+}
+
+// TestHandlerStopsTheProbesWhenTheClientGoesAway is the reason the handler
+// builds a collector for each request. A scrape that the Prometheus server
+// drops must not leave the probes running.
+func TestHandlerStopsTheProbesWhenTheClientGoesAway(t *testing.T) {
+	// The target holds the response, so only a cancelled probe ends it. It
+	// reports that its own context ended, which happens when the probe stops.
+	aborted := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	target := httptest.NewTLSServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case <-r.Context().Done():
+				select {
+				case aborted <- struct{}{}:
+				default:
+				}
+			case <-release:
+			}
+		}))
+	defer target.Close()
+	defer close(release)
+
+	// A timeout long enough that only the client going away ends the probe.
+	exporter, err := NewSSLExporter(&Config{
+		HTTPDomains: []HTTPDomain{{
+			Domain:             strings.TrimPrefix(target.URL, "https://"),
+			InsecureSkipVerify: true,
+		}},
+	}, time.Minute)
+	if err != nil {
+		t.Fatalf("NewSSLExporter: %v", err)
+	}
+
+	metrics := httptest.NewServer(exporter.Handler())
+	defer metrics.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metrics.URL, nil)
+	if err != nil {
+		t.Fatalf("build the request: %v", err)
+	}
+	if _, err := metrics.Client().Do(req); err == nil {
+		t.Fatal("the scrape finished, so the target did not hold the response")
+	}
+
+	select {
+	case <-aborted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the probe kept running after the client went away")
+	}
+}
 
 // TestCollectConcurrentTargets probes several targets in one scrape. The race
 // detector reports the shared-client fault here, because every probe runs in
@@ -39,7 +149,7 @@ func TestCollectConcurrentTargets(t *testing.T) {
 	}
 
 	registry := prometheus.NewPedanticRegistry()
-	if err := registry.Register(exporter); err != nil {
+	if err := registry.Register(exporter.newScrape(t.Context())); err != nil {
 		t.Fatalf("register the exporter: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -5,9 +5,6 @@ import (
 	"log"
 	"net/http"
 	"time"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -30,10 +27,8 @@ func main() {
 		log.Fatalf("couldn't build the exporter: %v", err)
 	}
 
-	prometheus.MustRegister(exporter)
-
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/metrics", exporter.Handler())
 
 	// The timeouts stop a client that opens a connection and then stalls.
 	// WriteTimeout covers the whole response, so it holds every probe of one

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -163,7 +163,7 @@ func gatherSMTP(t *testing.T, target SMTPDomain) float64 {
 	}
 
 	registry := prometheus.NewPedanticRegistry()
-	if err := registry.Register(exporter); err != nil {
+	if err := registry.Register(exporter.newScrape(t.Context())); err != nil {
 		t.Fatalf("register the exporter: %v", err)
 	}
 
@@ -249,7 +249,7 @@ func TestSMTPCertificateExpiry(t *testing.T) {
 	}
 
 	registry := prometheus.NewPedanticRegistry()
-	if err := registry.Register(exporter); err != nil {
+	if err := registry.Register(exporter.newScrape(t.Context())); err != nil {
 		t.Fatalf("register the exporter: %v", err)
 	}
 


### PR DESCRIPTION
The follow-up to #18. That change let a context cancel a probe, but the context came from `context.Background()`, so nothing ever cancelled it. Only the deadline did.

This gives the probes the context of the scrape request.

## Why the handler builds a registry for each request

`prometheus.Collector` takes no context:

```go
Collect(ch chan<- prometheus.Metric)
```

So a collector registered once at startup can never reach the request that asked for it. The way around it is one collector for each request, holding that context. `blackbox_exporter` and `ribbybibby/ssl_exporter` both work this way, so the shape is known in this ecosystem. Those two need it because their target list is per request, while this exporter needs it only for the context.

`Exporter` is therefore no longer a `Collector`. `Collect` becomes `collect(ctx, ch)`, and a small `scrape` type carries the context:

```go
type scrape struct {
    exporter *Exporter
    ctx      context.Context
}
```

The default gatherer joins the registry of the request, so `/metrics` still carries the `go_` and `process_` metrics.

## What I measured

A target that accepts TCP and never finishes the TLS handshake, and a client that gives up after 1 second:

| Build | The probe stopped after |
| --- | --- |
| `main` | 8.1 seconds, with `context deadline exceeded` |
| This branch | 1.0 second, with `context canceled` |

So `main` did 7 seconds of work for a scrape that nobody was waiting for.

I also checked a running build: three scrapes in a row each gave 2 `ssl_` series and 44 `go_` and `process_` lines, and two scrapes at the same time both gave 200. A registry that the handler kept between requests would fail the second scrape, so this is worth checking.

## Tests

Two new tests, and I ran both against the old behaviour first:

- `TestHandlerStopsTheProbesWhenTheClientGoesAway` sets the timeout of the exporter to one minute, so only the client going away can end the probe. Against `main` it waited the full minute and failed.
- `TestHandlerServesBothRegistries` scrapes twice and looks for `ssl_endpoint_up`, `ssl_cert_not_after` and `go_goroutines`.

29 tests, up from 27. Coverage is 84.1%. `go vet` and `golangci-lint run ./...` report nothing. The race detector does not run in my sandbox, so CI is the first `go test -race` of this branch.

## One note for operators

The README gets three lines. A scrape that Prometheus gives up on now stops its probes, so `scrape_timeout` needs to stay above `-timeout`.